### PR TITLE
Bump Tox constraint to <4, for release of Tox 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     maintainer="Dan Crosta",
     maintainer_email="dcrosta@late.am",
     install_requires=[
-        "docker>=2.3.0,<3.0",
+        "docker>=2.3.0,<4.0",
         "tox>=2.7.0,<3.0",
     ],
     py_modules=["tox_docker"],


### PR DESCRIPTION
I tested this with my local project (using tox-docker to run PostgreSQL), and things seem to work fine on Tox 3.0.0.

This should fix issue #4.